### PR TITLE
allow doctrine/cache v1.7 + allow doctrine/annotations v1.5 and v1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
   ],
   "require": {
     "php": ">=5.6",
-    "doctrine/annotations": "1.4.0",
+    "doctrine/annotations": "1.4.0 || 1.6.0",
     "nette/di": "^2.4.9",
     "nette/utils": "^2.4.8",
-    "doctrine/cache": "~1.6.2"
+    "doctrine/cache": "~1.6.2 || ~1.7.0"
   },
   "require-dev": {
     "ninjify/qa": "~0.4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=5.6",
-    "doctrine/annotations": "1.4.0 || 1.6.0",
+    "doctrine/annotations": "~1.4",
     "nette/di": "^2.4.9",
     "nette/utils": "^2.4.8",
     "doctrine/cache": "~1.6.2 || ~1.7.0"

--- a/src/DI/AnnotationsExtension.php
+++ b/src/DI/AnnotationsExtension.php
@@ -33,7 +33,7 @@ class AnnotationsExtension extends CompilerExtension
 
 		$reader = $builder->addDefinition($this->prefix('annotationReader'))
 			->setClass(AnnotationReader::class)
-			->setAutowired(FALSE);
+			->setAutowired(TRUE);
 
 		Validators::assertField($config, 'ignore', 'array');
 		foreach ($config['ignore'] as $annotationName) {


### PR DESCRIPTION
I was checked the release notes of doctrine/annotations, and no see any BC breaks between version 1.4.0 and latest 1.6.0, so i think can set composer to ~1.4 + allow doctrine/cache v1.7
