### PR TITLE
Rewrite

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -29,7 +29,6 @@ extensions:
 annotations:
     debug: %debugMode%
     ignore: []
-    cache: Doctrine\Common\Cache\FilesystemCache
 ```
 
 Optionally you can configure ignored annotations:
@@ -40,7 +39,7 @@ annotations:
         - someIgnoredAnnotation
 ```
 
-Refer already defined cache (instance of `Doctrine\Common\Cache`).
+Refer to specific cache service which implements `Doctrine\Common\Cache` (otherwise autowired one is used)
 
 ```yaml
 annotations:

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,17 @@
     {
       "name": "Milan Felix Šulc",
       "homepage": "https://f3l1x.io"
+    },
+    {
+      "name": "Marek Bartoš",
+      "homepage": "https://github.com/mabar"
     }
   ],
   "require": {
     "php": "^7.2",
+    "contributte/di": "^0.4.0",
     "doctrine/annotations": "^1.6.1",
-    "doctrine/cache": "^1.8.0",
-    "nette/di": "~3.0.0"
+    "doctrine/cache": "^1.8.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.2.2",

--- a/tests/cases/Unit/Reader/ReaderTest.php
+++ b/tests/cases/Unit/Reader/ReaderTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Cases\Unit\Reader;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\Reader;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
@@ -25,17 +24,18 @@ final class ReaderTest extends TestCase
 			$compiler->addConfig(['parameters' => ['tempDir' => TEMP_PATH]]);
 			$compiler->addConfig(NeonLoader::load('
 			annotations:
+				cache: Doctrine\Common\Cache\FilesystemCache(%tempDir%/nettrine.annotations)
 				ignore:
 					- ignoredAnnotation
-		', 'neon'));
+		'));
 			$compiler->addDependencies([__FILE__]);
 		}, __METHOD__);
 
-		/** @var Container $container */
 		$container = new $class();
+		assert($container instanceof Container);
 
-		/** @var AnnotationReader $reader */
 		$reader = $container->getByType(Reader::class);
+		assert($reader instanceof Reader);
 
 		$annotations = $reader->getClassAnnotations(new ReflectionClass(SampleClass::class));
 


### PR DESCRIPTION
- Added some by default ignored annotations (sync with abandoned contributte/phpdoc)
- By default is used an autowired cache service, but specific one could be also defined. Exception is thrown if cache is completely missing.
- Flexible service definition is used for cache https://contributte.org/blabs/2019/embedding-of-services-with-contributte-di.html