### PR TITLE
QA: fix Codesniffer ruleset reference

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Contributte" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<!-- Rulesets -->
-	<rule ref="./vendor/contributte/qa/ruleset-8.0.xml"/>
+	<rule ref="./vendor/contributte/qa/ruleset-8.2.xml"/>
 
 	<!-- Rules -->
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">


### PR DESCRIPTION
## Summary
- update `ruleset.xml` to use `./vendor/contributte/qa/ruleset-8.2.xml` because `ruleset-8.0.xml` no longer exists in `contributte/qa` v0.4
- this fixes the default-branch Codesniffer pipeline failure (`ERROR: Referenced sniff \"./vendor/contributte/qa/ruleset-8.0.xml\" does not exist.`)

## Verification
- `composer install --no-interaction --no-progress --prefer-dist`
- `make cs`
- `make phpstan`