### PR TITLE
CI: replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Switch the `coverage` Makefile target from `phpdbg` to plain `php` so it matches the org-wide coverage runner migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from coverage-related Makefile targets across Contributte. This repository should use the same `php` runner as the rest of the migration.

## Changes

- replace `-p phpdbg` with `-p php` in both coverage target branches in `Makefile`
- keep the existing coverage output behavior for CI and local runs

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification attempted with `make coverage`
- Local `make coverage` currently fails because this environment does not have Xdebug or PCOV loaded when running plain `php`